### PR TITLE
Disable auto save during server backup

### DIFF
--- a/src/me/zombie_striker/sr/Main.java
+++ b/src/me/zombie_striker/sr/Main.java
@@ -300,6 +300,7 @@ public class Main extends JavaPlugin {
 		for (World loaded : Bukkit.getWorlds()) {
 			try {
 				loaded.save();
+				loaded.setAutoSave(false);
 			} catch (Exception e) {
 			}
 		}
@@ -336,6 +337,12 @@ public class Main extends JavaPlugin {
 							- (tempBackupCheck.exists() ? folderSize(tempBackupCheck) : 0), false))
 							+ " to " + humanReadableByteCount(ff.length(), false));
 					currentlySaving = false;
+					for (World loaded : Bukkit.getWorlds()) {
+						try {
+							loaded.setAutoSave(true);
+						} catch (Exception e) {
+						}
+					}
 					if (useSFTP) {
 						try {
 							sender.sendMessage(prefix + " Starting SFTP Transfer");


### PR DESCRIPTION
Currently, if a world is being backed up while users are exploring new terrain or the server is saving chunks/entities it can cause severe corruption in said areas (this was tested with and without disabling auto save on a local server). In many instances I loaded a backup that was saved while exploring new terrain and the console spit out tons of "chunk in wrong location" errors, with obviously corrupted chunks in the world.
Disabling auto saves during a server backup fixes this.

Apologies if I missed something, this is essentially my first week messing with Minecraft plugins in a _long_ time.
See also: #5 