### PR TITLE
Fix backup.zip is a directory not a archive.

### DIFF
--- a/src/me/zombie_striker/sr/Main.java
+++ b/src/me/zombie_striker/sr/Main.java
@@ -390,13 +390,13 @@ public class Main extends JavaPlugin {
 					}
 					final long time = lastSave = System.currentTimeMillis();
 					Date d = new Date(System.currentTimeMillis());
-					File ff = new File(getBackupFolder(),
+					File zipFile = new File(getBackupFolder(),
 							naming_format.replaceAll("%date%", dateformat.format(d)) + ".zip");
-					if (!ff.exists()) {
-						ff.mkdirs();
-						ff.createNewFile();
+					if (!zipFile.exists()) {
+						getBackupFolder().mkdirs();
+						zipFile.createNewFile();
 					}
-					zipFolder(getMasterFolder().getPath(), ff.getPath());
+					zipFolder(getMasterFolder().getPath(), zipFile.getPath());
 					long timeDif = (System.currentTimeMillis() - time) / 1000;
 					String timeDifS = (((int) (timeDif / 60)) + "M, " + (timeDif % 60) + "S");
 					sender.sendMessage(prefix + " Done! Packing took:" + timeDifS);
@@ -404,7 +404,7 @@ public class Main extends JavaPlugin {
 					sender.sendMessage(prefix + " Compressed server with size of "
 							+ (humanReadableByteCount(folderSize(getMasterFolder())
 							- (tempBackupCheck.exists() ? folderSize(tempBackupCheck) : 0), false))
-							+ " to " + humanReadableByteCount(ff.length(), false));
+							+ " to " + humanReadableByteCount(zipFile.length(), false));
 					currentlySaving = false;
 					for (World world : autosave)
 						world.setAutoSave(true);
@@ -421,14 +421,14 @@ public class Main extends JavaPlugin {
 							sftp.connect(1000 * 20);
 						} catch (Exception | Error e) {
 							sender.sendMessage(
-									prefix + " FAILED TO SFTP TRANSFER FILE: " + ff.getName() + ". ERROR IN CONSOLE.");
+									prefix + " FAILED TO SFTP TRANSFER FILE: " + zipFile.getName() + ". ERROR IN CONSOLE.");
 							if (deleteZipOnFail)
-								ff.delete();
+								zipFile.delete();
 							e.printStackTrace();
 						}
 					} else if (useFTPS) {
 						sender.sendMessage(prefix + " Starting FTPS Transfer");
-						FileInputStream zipFileStream = new FileInputStream(ff);
+						FileInputStream zipFileStream = new FileInputStream(zipFile);
 						FTPSClient ftpClient = new FTPSClient();
 						try {
 							if (ftpClient.isConnected()) {
@@ -437,14 +437,14 @@ public class Main extends JavaPlugin {
 								ftpClient.disconnect();
 								ftpClient = new FTPSClient();
 							}
-							sendFTP(sender, ff, ftpClient, zipFileStream, removeFilePath);
+							sendFTP(sender, zipFile, ftpClient, zipFileStream, removeFilePath);
 							if (deleteZipOnFTP)
-								ff.delete();
+								zipFile.delete();
 						} catch (Exception | Error e) {
 							sender.sendMessage(
-									prefix + " FAILED TO FTPS TRANSFER FILE: " + ff.getName() + ". ERROR IN CONSOLE.");
+									prefix + " FAILED TO FTPS TRANSFER FILE: " + zipFile.getName() + ". ERROR IN CONSOLE.");
 							if (deleteZipOnFail)
-								ff.delete();
+								zipFile.delete();
 							e.printStackTrace();
 						} finally {
 							try {
@@ -459,7 +459,7 @@ public class Main extends JavaPlugin {
 						}
 					} else if (useFTP) {
 						sender.sendMessage(prefix + " Starting FTP Transfer");
-						FileInputStream zipFileStream = new FileInputStream(ff);
+						FileInputStream zipFileStream = new FileInputStream(zipFile);
 						FTPClient ftpClient = new FTPClient();
 						try {
 							if (ftpClient.isConnected()) {
@@ -468,14 +468,14 @@ public class Main extends JavaPlugin {
 								ftpClient.disconnect();
 								ftpClient = new FTPClient();
 							}
-							sendFTP(sender, ff, ftpClient, zipFileStream, removeFilePath);
+							sendFTP(sender, zipFile, ftpClient, zipFileStream, removeFilePath);
 							if (deleteZipOnFTP)
-								ff.delete();
+								zipFile.delete();
 						} catch (Exception | Error e) {
 							sender.sendMessage(
-									prefix + " FAILED TO FTP TRANSFER FILE: " + ff.getName() + ". ERROR IN CONSOLE.");
+									prefix + " FAILED TO FTP TRANSFER FILE: " + zipFile.getName() + ". ERROR IN CONSOLE.");
 							if (deleteZipOnFail)
-								ff.delete();
+								zipFile.delete();
 							e.printStackTrace();
 						} finally {
 							try {
@@ -496,7 +496,7 @@ public class Main extends JavaPlugin {
 		}.runTaskAsynchronously(this);
 	}
 
-	public void sendFTP(CommandSender sender, File ff, FTPClient ftpClient, FileInputStream zipFileStream, String path)
+	public void sendFTP(CommandSender sender, File zipFile, FTPClient ftpClient, FileInputStream zipFileStream, String path)
 			throws SocketException, IOException {
 		ftpClient.connect(serverFTP, portFTP);
 		ftpClient.login(userFTP, passwordFTP);
@@ -504,7 +504,7 @@ public class Main extends JavaPlugin {
 
 		ftpClient.setFileType(FTP.BINARY_FILE_TYPE);
 
-		boolean done = ftpClient.storeFile(path + ff.getName(), zipFileStream);
+		boolean done = ftpClient.storeFile(path + zipFile.getName(), zipFileStream);
 		zipFileStream.close();
 		if (done) {
 			sender.sendMessage(prefix + " Transfered backup using FTP!");


### PR DESCRIPTION
File.mkdirs() assumes the current file is a directory and creates a directory for it. Instead we want to call mkdirs on the parent directory.

This fixes #11, fixes #10 